### PR TITLE
UTF8 String and Date parsing issues Fixed

### DIFF
--- a/src/main/scala/com/microsoft/cdm/utils/Constants.scala
+++ b/src/main/scala/com/microsoft/cdm/utils/Constants.scala
@@ -8,11 +8,13 @@ import java.math.MathContext
 object Constants {
 
   // TODO: ensure these match the data provided
-  val DATE_FORMATS = Array("MM/dd/yyyy", "MM/dd/yyyy hh:mm:ss a")
-  val OUTPUT_FORMAT = "MM/dd/yyyy hh:mm:ss a"
+//  val DATE_FORMATS = Array("MM/dd/yyyy", "MM/dd/yyyy hh:mm:ss a")
+//  val OUTPUT_FORMAT = "MM/dd/yyyy hh:mm:ss a"
 
   val DECIMAL_PRECISION = 28
   val MATH_CONTEXT = new MathContext(28)
 
+  val SINGLE_DATE_FORMAT = "MM/dd/yyyy"
+  val TIMESTAMP_FORMAT = "MM/dd/yyyy hh:mm:ss a"
 
 }

--- a/src/main/scala/com/microsoft/cdm/utils/CsvParserFactory.scala
+++ b/src/main/scala/com/microsoft/cdm/utils/CsvParserFactory.scala
@@ -14,6 +14,7 @@ object CsvParserFactory {
     val format = settings.getFormat
     format.setDelimiter(',')
     settings.setMaxCharsPerColumn(500000)
+    settings.setMaxColumns(512 * 4)
     new CsvParser(settings)
   }
 

--- a/src/main/scala/com/microsoft/cdm/utils/DataConverter.scala
+++ b/src/main/scala/com/microsoft/cdm/utils/DataConverter.scala
@@ -1,9 +1,12 @@
 package com.microsoft.cdm.utils
 
 import java.text.SimpleDateFormat
+import java.util.{Locale, TimeZone}
 
 import org.apache.commons.lang.time.DateUtils
+import org.apache.spark.sql.catalyst.util.{DateTimeUtils, TimestampFormatter}
 import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.UTF8String
 
 /**
   * Converts between CSV/CDM data and Spark data tpyes.
@@ -15,19 +18,24 @@ class DataConverter(val dateFormats: Array[String] = Constants.DATE_FORMATS,
 
   val dateFormatter = new SimpleDateFormat(outputDateFormat)
 
+  private val timestampFormatter = TimestampFormatter("MM/dd/yyyy", TimeZone.getTimeZone("UTC"), Locale.US
+
+  var format = new SimpleDateFormat("MM/dd/yyyy hh:mm:ss a", Locale.US)
+  var format2 = new SimpleDateFormat("MM/dd/yyyy")
+
   val toSparkType: Map[CDMDataType.Value, DataType] = Map(
     CDMDataType.int64 -> LongType,
-    CDMDataType.dateTime -> DateType,
+    CDMDataType.dateTime -> TimestampType,
     CDMDataType.string -> StringType,
     CDMDataType.double -> DoubleType,
     CDMDataType.decimal -> DecimalType(Constants.DECIMAL_PRECISION,0),
     CDMDataType.boolean -> BooleanType,
-    CDMDataType.dateTimeOffset -> DateType
+    CDMDataType.dateTimeOffset -> TimestampType
   )
 
   val toCdmType: Map[DataType, CDMDataType.Value] = Map(
     LongType -> CDMDataType.int64,
-    DateType -> CDMDataType.dateTime,
+    TimestampType -> CDMDataType.dateTime,
     StringType -> CDMDataType.string,
     DoubleType -> CDMDataType.double,
     DecimalType(Constants.DECIMAL_PRECISION,0) -> CDMDataType.decimal,
@@ -36,18 +44,19 @@ class DataConverter(val dateFormats: Array[String] = Constants.DATE_FORMATS,
 
   val jsonToData: Map[DataType, String => Any] = Map(
     LongType -> (x => x.toLong),
-    StringType -> (x => x),
+    StringType -> (x => UTF8String.fromString(x)),
     DoubleType -> (x => x.toDouble),
     DecimalType(Constants.DECIMAL_PRECISION,0) -> (x => BigDecimal(x, Constants.MATH_CONTEXT)),
     BooleanType -> (x => x.toBoolean),
-    DateType -> (x => new java.sql.Date(DateUtils.parseDate(x, dateFormats).getTime))
+//    TimestampType -> (x => DateUtils.parseDate(x, dateFormats).getTime)
+    TimestampType -> (x => timestampFormatter.parse(format2.format(format.parse(x))))
   )
 
   def dataToString(data: Any, dataType: DataType): String = {
     if(data == null) {
       null
     }
-    else if(dataType == DateType) {
+    else if(dataType == TimestampType) {
       dateFormatter.format(data)
     }
     else {


### PR DESCRIPTION
This PR fixes the UTF-8 String and date parsing issues.
Apparently, the OP was not converting the data strings into the desired format used by Scala. The code is working now and I have also updated the release jar.

Feel free to put your comments for the PR.

Cheers,
Deepanshu