### PR TITLE
quote all fields to avoid some compatibility issues

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "spark-cdm"
 
-version := "0.3"
+version := "0.3~markbaas"
 
 scalaVersion := "2.11.8"
 

--- a/src/main/scala/com/microsoft/cdm/utils/CsvParserFactory.scala
+++ b/src/main/scala/com/microsoft/cdm/utils/CsvParserFactory.scala
@@ -18,7 +18,9 @@ object CsvParserFactory {
   }
 
   def buildWriter(outputWriter: OutputStreamWriter): CsvWriter = {
-    new CsvWriter(outputWriter, new CsvWriterSettings())
+    val settings = new CsvWriterSettings()
+    settings.setQuoteAllFields(true);
+    new CsvWriter(outputWriter, settings)
   }
 
 }


### PR DESCRIPTION
Field with double quotes are not quoted properly causing power bi to not load the csv correctly. This workaround assures that all fields are loaded correctly. Types are of no concern as the model.json already defines this.