### PR TITLE
Bugfix: request body is too large

### DIFF
--- a/src/main/scala/com/microsoft/cdm/utils/ADLGen2Provider.scala
+++ b/src/main/scala/com/microsoft/cdm/utils/ADLGen2Provider.scala
@@ -9,7 +9,7 @@ import org.apache.commons.httpclient.HttpStatus
 import org.apache.commons.io.{Charsets, IOUtils}
 import org.apache.http.client.utils.URIBuilder
 import org.apache.http.{HttpEntity, HttpResponse, NameValuePair}
-import org.apache.http.entity.{FileEntity, StringEntity}
+import org.apache.http.entity.{FileEntity, StringEntity, ByteArrayEntity}
 import org.apache.http.impl.client.{BasicResponseHandler, DefaultHttpClient}
 import org.apache.http.message.BasicNameValuePair
 
@@ -175,7 +175,13 @@ class ADLGen2Provider(aadProvider: AADProvider) extends Serializable {
   private def createAndUpload(uri: String, entity: HttpEntity, bearerToken: String): Unit = {
     createFile(uri, bearerToken)
     if(entity.getContentLength > 0) {
-      appendToFile(uri, entity, bearerToken)
+      val content = entity.getContent
+      val buffer = new Array[Byte](100000)
+
+      while (content.read(buffer) != -1) {
+        val chunk = new ByteArrayEntity(buffer)
+        appendToFile(uri, chunk, bearerToken) 
+      } 
       flushFile(uri, bearerToken, entity.getContentLength)
     }
   }

--- a/src/main/scala/com/microsoft/cdm/utils/ADLGen2Provider.scala
+++ b/src/main/scala/com/microsoft/cdm/utils/ADLGen2Provider.scala
@@ -176,7 +176,7 @@ class ADLGen2Provider(aadProvider: AADProvider) extends Serializable {
     createFile(uri, bearerToken)
     if(entity.getContentLength > 0) {
       val content = entity.getContent
-      val buffer = new Array[Byte](100000)
+      val buffer = new Array[Byte](100000000)
 
       while (content.read(buffer) != -1) {
         val chunk = new ByteArrayEntity(buffer)


### PR DESCRIPTION
Writing big dataframes on one partition causes a response error "Request body is too large".

This PR writes chunks of 100M (blob update limit).