### PR TITLE
parser should match formatter

### DIFF
--- a/src/main/scala/com/microsoft/cdm/read/CDMDataReader.scala
+++ b/src/main/scala/com/microsoft/cdm/read/CDMDataReader.scala
@@ -51,7 +51,7 @@ class CDMDataReader(var remoteCSVPath: String,
         null
       }
       else {
-        dataConverter.jsonToData(schema.fields(index).dataType)(col)
+        dataConverter.jsonToData(schema.fields(index).dataType, col)
       }
     }
     InternalRow.fromSeq(seq)

--- a/src/main/scala/com/microsoft/cdm/utils/Constants.scala
+++ b/src/main/scala/com/microsoft/cdm/utils/Constants.scala
@@ -14,7 +14,7 @@ object Constants {
   val DECIMAL_PRECISION = 28
   val MATH_CONTEXT = new MathContext(28)
 
-  val SINGLE_DATE_FORMAT = "MM/dd/yyyy"
-  val TIMESTAMP_FORMAT = "MM/dd/yyyy hh:mm:ss a"
+  val SINGLE_DATE_FORMAT = "yyyy-MM-dd"
+  val TIMESTAMP_FORMAT = "yyyy-MM-dd'T'hh:mm:ssX" // ISO8601
 
 }

--- a/src/main/scala/com/microsoft/cdm/utils/DataConverter.scala
+++ b/src/main/scala/com/microsoft/cdm/utils/DataConverter.scala
@@ -31,7 +31,7 @@ class DataConverter() extends Serializable {
     return dt match {
       case LongType => value.toLong
       case DoubleType => value.toDouble
-      case DecimalType() => BigDecimal(value, Constants.MATH_CONTEXT)
+      case DecimalType() => Decimal(value)
       case BooleanType => value.toBoolean
       case DateType => dateFormatter.parse(value)
       case TimestampType => timestampFormatter.parse(value).getTime()

--- a/src/main/scala/com/microsoft/cdm/utils/DataConverter.scala
+++ b/src/main/scala/com/microsoft/cdm/utils/DataConverter.scala
@@ -4,7 +4,6 @@ import java.text.SimpleDateFormat
 import java.util.{Locale, TimeZone}
 
 import org.apache.commons.lang.time.DateUtils
-import org.apache.spark.sql.catalyst.util.{DateFormatter, DateTimeUtils, TimestampFormatter}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -13,16 +12,10 @@ import org.apache.spark.unsafe.types.UTF8String
   * @param dateFormats Expected string date formats.
   * @param outputDateFormat Output date format.
   */
-class DataConverter(val dateFormats: String = Constants.TIMESTAMP_FORMAT,
-                    val outputDateFormat: String = Constants.TIMESTAMP_FORMAT) extends Serializable {
+class DataConverter() extends Serializable {
 
-  val dateFormatter = new SimpleDateFormat(outputDateFormat)
-
-  private val timestampFormatter = TimestampFormatter(Constants.SINGLE_DATE_FORMAT, TimeZone.getTimeZone("UTC"))
-  private val inputDateFormatter = DateFormatter(Constants.SINGLE_DATE_FORMAT)
-
-  var timeformat = new SimpleDateFormat(Constants.TIMESTAMP_FORMAT, Locale.US)
-  var dateformat = new SimpleDateFormat(Constants.SINGLE_DATE_FORMAT)
+  val dateFormatter = new SimpleDateFormat(Constants.SINGLE_DATE_FORMAT)
+  val timestampFormatter = new SimpleDateFormat(Constants.TIMESTAMP_FORMAT)
 
   val toSparkType: Map[CDMDataType.Value, DataType] = Map(
     CDMDataType.int64 -> LongType,
@@ -41,7 +34,7 @@ class DataConverter(val dateFormats: String = Constants.TIMESTAMP_FORMAT,
     DecimalType(Constants.DECIMAL_PRECISION,0) -> (x => BigDecimal(x, Constants.MATH_CONTEXT)),
     BooleanType -> (x => x.toBoolean),
     DateType -> (x => dateFormatter.parse(x)),
-    TimestampType -> (x => dateFormatter.parse(x))
+    TimestampType -> (x => timestampFormatter.parse(x))
   )
 
   def toCdmType(dt: DataType): CDMDataType.Value = {
@@ -63,6 +56,9 @@ class DataConverter(val dateFormats: String = Constants.TIMESTAMP_FORMAT,
     }
     else if(dataType == DateType) {
       dateFormatter.format(data)
+    }
+    else if(dataType == TimestampType) {
+      timestampFormatter.format(data)
     }
     else {
       data.toString

--- a/src/main/scala/com/microsoft/cdm/utils/DataConverter.scala
+++ b/src/main/scala/com/microsoft/cdm/utils/DataConverter.scala
@@ -27,15 +27,17 @@ class DataConverter() extends Serializable {
     CDMDataType.dateTimeOffset -> TimestampType
   )
 
-  val jsonToData: Map[DataType, String => Any] = Map(
-    LongType -> (x => x.toLong),
-    StringType -> (x => UTF8String.fromString(x)),
-    DoubleType -> (x => x.toDouble),
-    DecimalType(Constants.DECIMAL_PRECISION,0) -> (x => BigDecimal(x, Constants.MATH_CONTEXT)),
-    BooleanType -> (x => x.toBoolean),
-    DateType -> (x => dateFormatter.parse(x)),
-    TimestampType -> (x => timestampFormatter.parse(x))
-  )
+  def jsonToData(dt: DataType, value: String): Any = {
+    return dt match {
+      case LongType => value.toLong
+      case DoubleType => value.toDouble
+      case DecimalType() => BigDecimal(value, Constants.MATH_CONTEXT)
+      case BooleanType => value.toBoolean
+      case DateType => dateFormatter.parse(value)
+      case TimestampType => timestampFormatter.parse(value).getTime()
+      case _ => UTF8String.fromString(value)
+    }
+  }
 
   def toCdmType(dt: DataType): CDMDataType.Value = {
     return dt match {

--- a/src/main/scala/com/microsoft/cdm/utils/DataConverter.scala
+++ b/src/main/scala/com/microsoft/cdm/utils/DataConverter.scala
@@ -40,10 +40,8 @@ class DataConverter(val dateFormats: String = Constants.TIMESTAMP_FORMAT,
     DoubleType -> (x => x.toDouble),
     DecimalType(Constants.DECIMAL_PRECISION,0) -> (x => BigDecimal(x, Constants.MATH_CONTEXT)),
     BooleanType -> (x => x.toBoolean),
-//    DateType -> (x => inputDateFormatter.parse(x)),
-//    TimestampType -> (x => timestampFormatter.parse(x))
-    DateType -> (x => inputDateFormatter.parse(dateformat.format(timeformat.parse(x)))),
-    TimestampType -> (x => timestampFormatter.parse(dateformat.format(timeformat.parse(x))))
+    DateType -> (x => dateFormatter.parse(x)),
+    TimestampType -> (x => dateFormatter.parse(x))
   )
 
   def toCdmType(dt: DataType): CDMDataType.Value = {


### PR DESCRIPTION
fixes parsing date(times) and set the datetime for to always follow iso8601 as described in:
https://docs.microsoft.com/en-us/common-data-model/model-json#datatype-formats

Additionally while testing, I could the following exception:
```java.math.BigDecimal cannot be cast to org.apache.spark.sql.types.Decimal```

Changing BigDecimal to Spark Decimal type solved the issue.