### PR TITLE
uses the spark timestampformatter for timestamp

### DIFF
--- a/src/main/scala/com/microsoft/cdm/utils/Constants.scala
+++ b/src/main/scala/com/microsoft/cdm/utils/Constants.scala
@@ -15,6 +15,6 @@ object Constants {
   val MATH_CONTEXT = new MathContext(28)
 
   val SINGLE_DATE_FORMAT = "yyyy-MM-dd"
-  val TIMESTAMP_FORMAT = "yyyy-MM-dd'T'hh:mm:ssX" // ISO8601
+  val TIMESTAMP_FORMAT = "yyyy-MM-dd'T'hh:mm:ss" // ISO8601
 
 }


### PR DESCRIPTION
Seems the previous pull request made all timestamps to be written back and datetimes parsed from microseconds. Change the timestampformatter to the one from spark fixes that. I only could get the timezone part of the format working, should matter too much as it is now set to UTC. I will think of a solution for this in the future.